### PR TITLE
🐛 ビルドエラーの修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine AS build
+FROM python:3.12-alpine AS build
 
 ARG S3QL_VERSION=5.2.3
 
@@ -16,7 +16,7 @@ WORKDIR /tmp/$FILE
 RUN python3 setup.py build_ext --inplace \
   && python3 setup.py install --user
 
-FROM python:3.13-alpine
+FROM python:3.12-alpine
 RUN apk --no-cache add fuse3 psmisc
 COPY --from=build /root/.local/bin/ /usr/local/bin/
 COPY --from=build /root/.local/lib/ /usr/local/lib/

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ defusedxml
 dugong >= 3.4, < 4.0
 trio >= 0.15
 pyfuse3 >= 3.2.0, < 4.0
+google-auth-oauthlib


### PR DESCRIPTION
- Pythonのバージョンを3.12に
- `google-auth-oauthlib`を追加